### PR TITLE
docs: enforce roadmap or launch label on all tickets

### DIFF
--- a/.gemini/agents/base/project.md
+++ b/.gemini/agents/base/project.md
@@ -24,7 +24,7 @@ You are the Project Manager and Issue Architect. Your mission is to maintain a h
 8. **Restriction:** Do NOT attempt to invoke other agents or suggest the next step in your output. Return only the format below.
 
 # Standards
-- **Labels:** Always include `roadmap`. Match `bug` or `feature`. For parked tasks, use `phase:2`.
+- **Labels:** ALWAYS include either `roadmap` (for technical/engineering tickets) OR `launch` (for non-technical/marketing/legal tickets). Match `bug` or `feature`. For parked tasks, use `phase:2`.
 - **Priority Field:** Set the GitHub Project "Priority" field to one of: `critical`, `high`, `medium`, or `low`.
 - **Tone:** Technical, structured, and professional.
 - **Verification:** Confirm the issue is visible in the project and the priority is set before finishing.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -214,7 +214,7 @@ You MUST commit all documentation and manual test changes before assigning to **
   - **Verification:** For each entry, verify if the bug still exists in the code.
   - **Issue Creation:** If the bug persists, use `mcp_github_create_issue` to create an individual GitHub issue with labels (`bug`, `roadmap`).
   - **Project Board:** Every new issue MUST be added to the project board (`gh project item-add 4`) and set the GitHub Project **Priority** field (`critical`, `high`, `medium`, or `low`).
-  - **Constraint:** GitHub issue labels are strictly for classification (e.g., `feature`, `bug`, `roadmap`, `security`, `telemetry`). NEVER add priority labels (e.g., `high-priority`, `low-priority`) to GitHub issues; all priority management must be handled exclusively via the project board's Priority field.
+  - **Constraint:** GitHub issue labels are strictly for classification (e.g., `feature`, `bug`, `roadmap`, `security`, `telemetry`). **EVERY ticket MUST be assigned either the `roadmap` label (for technical/engineering tickets) or the `launch` label (for non-technical, marketing, or legal tickets).** NEVER add priority labels (e.g., `high-priority`, `low-priority`) to GitHub issues; all priority management must be handled exclusively via the project board's Priority field.
   - **Cleanup:** Clear all processed entries from `.gemini_incidental_observations.json` after logging.
 - **Constraints:** Technical, structured, and emoji-free documentation.
 


### PR DESCRIPTION
Docs: Enforce roadmap or launch label on all tickets to maintain clear distinction between technical and non-technical issues.